### PR TITLE
Handle duplicate Blockasset data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,7 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+trending.csv
+trending.db
+blockasset.csv
+blockasset.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # Codex-
--
+
+This repo includes Python scripts with small demos.
+
+## Scripts
+
+- `hello.py` prints "Hello, world!".
+- `crypto_trending.py` lists trending cryptocurrencies from the public CoinGecko API, calculates a basic RSI indicator and can store the results in a CSV file or SQLite database.
+- `blockasset_data.py` downloads price history for the Blockasset coin and can save the data to CSV or SQLite.
+
+### Running the scripts
+
+To run the hello script:
+
+```bash
+python3 hello.py
+```
+
+To fetch trending coins (requires `requests`):
+
+```bash
+pip install requests
+python3 crypto_trending.py
+```
+
+The script prints each trending coin along with a 14-day RSI and a simple trading signal (``buy``, ``sell`` or ``neutral``).
+
+To store the results in a CSV file:
+
+```bash
+python3 crypto_trending.py --csv trending.csv
+```
+
+To store the results in a SQLite database:
+
+```bash
+python3 crypto_trending.py --db trending.db
+```
+
+To fetch all Blockasset price data and store it in CSV and SQLite files:
+
+The market data endpoint occasionally returns a duplicate entry for the
+current day. The script automatically removes duplicates so the CSV and
+database contain one row per day.
+
+```bash
+python3 blockasset_data.py --csv blockasset.csv --db blockasset.db
+```

--- a/blockasset_data.py
+++ b/blockasset_data.py
@@ -1,0 +1,110 @@
+import argparse
+import csv
+import sqlite3
+import requests
+from typing import List, Tuple
+from datetime import datetime
+
+COIN_ID = "blockasset"
+
+
+def fetch_coin_details() -> dict:
+    """Fetch detailed information about Blockasset."""
+    url = f"https://api.coingecko.com/api/v3/coins/{COIN_ID}"
+    params = {
+        "localization": "false",
+        "tickers": "false",
+        "market_data": "true",
+        "community_data": "true",
+        "developer_data": "true",
+        "sparkline": "false",
+    }
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_price_history(days: int = 365) -> List[Tuple[int, float]]:
+    """Return list of (timestamp, price) for the given number of days.
+
+    CoinGecko sometimes returns a duplicate entry for the most recent day.
+    Deduplicate by keeping the last price for each date.
+    """
+    url = f"https://api.coingecko.com/api/v3/coins/{COIN_ID}/market_chart"
+    params = {"vs_currency": "usd", "days": days, "interval": "daily"}
+    resp = requests.get(url, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+
+    per_date = {}
+    for ts, price in data.get("prices", []):
+        date = datetime.utcfromtimestamp(ts / 1000).strftime("%Y-%m-%d")
+        per_date[date] = (int(ts), float(price))
+
+    rows = [per_date[d] for d in sorted(per_date)]
+    return rows
+
+
+def save_csv(rows: List[Tuple[int, float]], path: str) -> None:
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["date", "price_usd"])
+        for ts, price in rows:
+            date = datetime.utcfromtimestamp(ts / 1000).strftime("%Y-%m-%d")
+            writer.writerow([date, price])
+
+
+def save_db(rows: List[Tuple[int, float]], path: str) -> None:
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE IF NOT EXISTS prices (date TEXT, price REAL)")
+    cur.execute("DELETE FROM prices")
+    cur.executemany(
+        "INSERT INTO prices (date, price) VALUES (?, ?)",
+        [
+            (datetime.utcfromtimestamp(ts / 1000).strftime("%Y-%m-%d"), price)
+            for ts, price in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fetch Blockasset price history")
+    parser.add_argument("--csv", help="Path to CSV file to store price history")
+    parser.add_argument("--db", help="Path to SQLite DB to store price history")
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=365,
+        help="Number of days of historical data to fetch (default: 365)",
+    )
+    args = parser.parse_args()
+
+    print("Fetching coin details...")
+    info = fetch_coin_details()
+    name = info.get("name")
+    symbol = info.get("symbol")
+    current = info.get("market_data", {}).get("current_price", {}).get("usd")
+    print(f"{name} ({symbol}) current price: {current} USD")
+
+    print("Fetching historical prices...")
+    prices = fetch_price_history(days=args.days)
+    print(f"Fetched {len(prices)} daily prices")
+    if prices:
+        first_date = datetime.utcfromtimestamp(prices[0][0] / 1000).strftime("%Y-%m-%d")
+        last_date = datetime.utcfromtimestamp(prices[-1][0] / 1000).strftime("%Y-%m-%d")
+        print(f"Range: {first_date} to {last_date}")
+
+    if args.csv:
+        save_csv(prices, args.csv)
+        print(f"Saved CSV to {args.csv}")
+
+    if args.db:
+        save_db(prices, args.db)
+        print(f"Saved DB to {args.db}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crypto_trending.py
+++ b/crypto_trending.py
@@ -1,0 +1,142 @@
+import argparse
+import csv
+import sqlite3
+import requests
+from typing import List, Dict, Tuple, Optional
+import math
+
+def fetch_trending() -> List[Dict[str, str]]:
+    """Return a list of trending coins with id, name and symbol."""
+    url = "https://api.coingecko.com/api/v3/search/trending"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    coins = data.get("coins", [])
+    results = []
+    for c in coins:
+        item = c.get("item", {})
+        results.append(
+            {
+                "id": item.get("id"),
+                "name": item.get("name"),
+                "symbol": item.get("symbol"),
+            }
+        )
+    return results
+
+
+def fetch_prices(coin_id: str, days: int = 15) -> List[float]:
+    """Fetch daily closing prices for the given coin id."""
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/market_chart"
+    params = {"vs_currency": "usd", "days": days, "interval": "daily"}
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+    except requests.RequestException:
+        return []
+    data = resp.json()
+    prices = [p[1] for p in data.get("prices", [])]
+    return prices
+
+
+def compute_rsi(prices: List[float], period: int = 14) -> Optional[float]:
+    """Return the RSI for the given list of prices."""
+    if len(prices) <= period:
+        return None
+    gains = []
+    losses = []
+    for i in range(1, period + 1):
+        delta = prices[i] - prices[i - 1]
+        if delta > 0:
+            gains.append(delta)
+        else:
+            losses.append(-delta)
+    avg_gain = sum(gains) / period
+    avg_loss = sum(losses) / period
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def analyze_coin(coin: Dict[str, str]) -> Tuple[str, float, str]:
+    """Return (symbol, rsi, signal) for a coin."""
+    prices = fetch_prices(coin["id"])
+    rsi = compute_rsi(prices)
+    if rsi is None:
+        signal = "neutral"
+    elif rsi < 30:
+        signal = "buy"
+    elif rsi > 70:
+        signal = "sell"
+    else:
+        signal = "neutral"
+    return coin["symbol"], rsi if rsi is not None else float("nan"), signal
+
+def save_csv(rows, path):
+    """Save results to a CSV file."""
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f, fieldnames=["name", "symbol", "rsi", "signal"]
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def save_db(rows, path):
+    """Save results to a SQLite database."""
+    conn = sqlite3.connect(path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS trending (name TEXT, symbol TEXT, rsi REAL, signal TEXT)"
+    )
+    cur.execute("DELETE FROM trending")
+    cur.executemany(
+        "INSERT INTO trending (name, symbol, rsi, signal) VALUES (?, ?, ?, ?)",
+        [
+            (r["name"], r["symbol"], r["rsi"], r["signal"])
+            for r in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch trending cryptocurrencies from CoinGecko"
+    )
+    parser.add_argument(
+        "--csv", help="Path to CSV file to store the results"
+    )
+    parser.add_argument(
+        "--db", help="Path to SQLite database to store the results"
+    )
+    args = parser.parse_args()
+
+    coins = fetch_trending()[:7]
+    results = []
+    for coin in coins:
+        symbol, rsi, signal = analyze_coin(coin)
+        results.append(
+            {
+                "name": coin["name"],
+                "symbol": symbol,
+                "rsi": round(rsi, 2) if not math.isnan(rsi) else None,
+                "signal": signal,
+            }
+        )
+        rsi_display = f"{rsi:.2f}" if not math.isnan(rsi) else "n/a"
+        print(f"{coin['name']} ({symbol}) - RSI {rsi_display} -> {signal}")
+
+    if args.csv:
+        save_csv(results, args.csv)
+        print(f"Saved results to {args.csv}")
+
+    if args.db:
+        save_db(results, args.db)
+        print(f"Saved results to {args.db}")
+
+
+if __name__ == "__main__":
+    main()

--- a/hello.py
+++ b/hello.py
@@ -1,0 +1,1 @@
+print("Hello, world!")


### PR DESCRIPTION
## Summary
- deduplicate Blockasset prices returned by the API
- mention duplicate handling in README

## Testing
- `python3 hello.py`
- `python3 crypto_trending.py | head`
- `python3 crypto_trending.py --csv trending.csv --db trending.db`
- `sqlite3 trending.db 'SELECT COUNT(*) FROM trending;'`
- `python3 blockasset_data.py --csv blockasset.csv --db blockasset.db`
- `sqlite3 blockasset.db 'SELECT COUNT(*) FROM prices;'`


------
https://chatgpt.com/codex/tasks/task_e_684b3d115aac8325a3f2411c45db918f